### PR TITLE
Make location configurable

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -296,7 +296,8 @@ const HdateButton = new GObject.registerClass({
         updateHighlight();
 
         let tzList = new St.ScrollView({
-            style: 'background: rgba(255,255,255,0.95); border: 1px solid rgba(0,0,0,0.2); max-height: 180px; width: 340px; margin-left: 10px; margin-right: 10px;',
+            style_class: 'popup-menu-content',
+            style: 'background-color: rgba(0,0,0,0.05); max-height: 180px; width: 340px; margin-left: 10px; margin-right: 10px; border: 1px solid rgba(0,0,0,0.15);',
             x_expand: true,
             y_expand: false
         });
@@ -346,7 +347,8 @@ const HdateButton = new GObject.registerClass({
         let dialogContainer = new St.BoxLayout({
             vertical: true,
             reactive: true,
-            style: 'background-color: #f0f0f0; border-radius: 10px; padding: 20px; width: 360px;'
+            style_class: 'popup-menu-content',
+            style: 'border-radius: 10px; padding: 20px; width: 360px;'
         });
         
         // Center horizontally and position near top

--- a/extension.js
+++ b/extension.js
@@ -213,16 +213,20 @@ const HdateButton = new GObject.registerClass({
 
         let tzEntry = new St.Entry({
             text: formatTz(this.settings.tz),
-            style: 'width: 320px; margin: 10px;'
+            style: 'width: 70px; margin: 10px;',
+            y_align: Clutter.ActorAlign.CENTER
         });
-        let tzEntryLabel = new St.Label({ text: _('Timezone (UTC offset):') });
+        let tzEntryLabel = new St.Label({ 
+            text: _('Timezone (UTC offset):'),
+            y_align: Clutter.ActorAlign.CENTER
+        });
         let tzEntryBox = new St.BoxLayout({
             vertical: false,
             style: 'spacing: 10px; margin: 10px;'
         });
         tzEntryBox.add_child(tzEntryLabel);
         tzEntryBox.add_child(tzEntry);
-        dialog.add_child(tzEntryBox);
+        // dialog.add_child(tzEntryBox);
 
         // Time zone dropdown (common locations)
         let tzOptions = [
@@ -240,15 +244,6 @@ const HdateButton = new GObject.registerClass({
 
         let selectedTz = this.settings.tz;
 
-        function tzLabel(val) {
-            let sign = val >= 0 ? '+' : '';
-            return _('Time zone:') + ` UTC${sign}${val}`;
-        }
-
-        let tzButton = new St.Button({
-            label: tzLabel(selectedTz),
-            style: 'width: 320px; margin: 10px; text-align: left;'
-        });
 
         let tzListBox = new St.BoxLayout({
             vertical: true,
@@ -279,7 +274,6 @@ const HdateButton = new GObject.registerClass({
             item.connect('clicked', () => {
                 selectedTz = option.value;
                 updateHighlight();
-                tzButton.set_label(tzLabel(selectedTz));
                 tzEntry.text = formatTz(selectedTz);
             });
             tzListBox.add_child(item);
@@ -295,7 +289,7 @@ const HdateButton = new GObject.registerClass({
         });
         tzList.add_child(tzListBox);
 
-        dialog.add_child(tzButton);
+        dialog.add_child(tzEntryBox);
         dialog.add_child(tzList);
 
         // Button container (centered)
@@ -323,6 +317,13 @@ const HdateButton = new GObject.registerClass({
             reactive: true
         });
         
+        // Push modal to capture input
+        let modalParams = {
+            actionMode: Shell.ActionMode.ALL,
+            shouldTakeFocus: true
+        };
+        Main.pushModal(background, modalParams);
+        
 
         let dialogContainer = new St.BoxLayout({
             vertical: true,
@@ -340,6 +341,12 @@ const HdateButton = new GObject.registerClass({
 
         background.add_child(dialogContainer);
 
+        let closeDialog = () => {
+            Main.popModal(background);
+            Main.uiGroup.remove_child(background);
+            background.destroy();
+        };
+
         okButton.connect('clicked', () => {
             let lon = parseFloat(lonInput.text);
             let lat = parseFloat(latInput.text);
@@ -355,14 +362,12 @@ const HdateButton = new GObject.registerClass({
                 this._applySettings();
                 this._refresh_button_menu(); // Force menu refresh with new location
 
-                Main.uiGroup.remove_child(background);
-                background.destroy();
+                closeDialog();
             }
         });
 
         cancelButton.connect('clicked', () => {
-            Main.uiGroup.remove_child(background);
-            background.destroy();
+            closeDialog();
         });
 
         Main.uiGroup.add_child(background);

--- a/extension.js
+++ b/extension.js
@@ -82,7 +82,7 @@ const HdateButton = new GObject.registerClass({
         let settings = loadSettings();
         this.settings = settings;
         
-        // init the hebrew date object
+        // init the hebrew date objectq
         this.h = LibHDateGLib.Hdate.new();
         this.h.set_dst(0);
         this.jd = 0;
@@ -117,8 +117,10 @@ const HdateButton = new GObject.registerClass({
         this.h.set_latitude(this.settings.latitude);
         this.h.set_tz(this.settings.tz);
 
-        this._refresh_button_menu(); // Force menu refresh with new location
-        this._refresh();
+        this.h.set_use_hebrew(true);
+        this.h.set_use_short_format(false);
+
+        // Don't call _refresh_button_menu() here - _refresh() will handle it
     }
 
     _refresh_button_label() {
@@ -156,33 +158,42 @@ const HdateButton = new GObject.registerClass({
         });
         dialog.add_child(titleLabel);
 
-        // Longitude input
-        let longtitudeBox = new St.BoxLayout({
-            vertical: false,
+        // Create table-like layout for coordinates using BoxLayout
+        let coordContainer = new St.BoxLayout({
+            vertical: true,
             style: 'spacing: 10px; margin: 10px;'
         });
-        let lonLabel = new St.Label({ text: _('Longitude:') });
-        let lonInput = new St.Entry({
-            text: this.settings.longitude.toString(),
-            style: 'width: 150px;'
-        });
-        longtitudeBox.add_child(lonLabel);
-        longtitudeBox.add_child(lonInput);
-        dialog.add_child(longtitudeBox);
 
-        // Latitude input
-        let latitudeBox = new St.BoxLayout({
+        // Latitude row
+        let latBox = new St.BoxLayout({
             vertical: false,
-            style: 'spacing: 10px; margin: 10px;'
+            style: 'spacing: 10px;'
         });
-        let latLabel = new St.Label({ text: _('Latitude:') });
+        let latLabel = new St.Label({ text: _('Latitude (°N):'), style: 'width: 120px;' });
         let latInput = new St.Entry({
             text: this.settings.latitude.toString(),
             style: 'width: 150px;'
         });
-        latitudeBox.add_child(latLabel);
-        latitudeBox.add_child(latInput);
-        dialog.add_child(latitudeBox);
+        latBox.add_child(latLabel);
+        latBox.add_child(latInput);
+        coordContainer.add_child(latBox);
+
+        // Longitude row
+        let lonBox = new St.BoxLayout({
+            vertical: false,
+            style: 'spacing: 10px;'
+        });
+        let lonLabel = new St.Label({ text: _('Longitude (°E):'), style: 'width: 120px;' });
+        let lonInput = new St.Entry({
+            text: this.settings.longitude.toString(),
+            style: 'width: 150px;'
+        });
+        lonBox.add_child(lonLabel);
+        lonBox.add_child(lonInput);
+        coordContainer.add_child(lonBox);
+
+        dialog.add_child(coordContainer);
+
 
         // Time zone entry (free-form)
         function formatTz(val) {
@@ -244,19 +255,38 @@ const HdateButton = new GObject.registerClass({
             style: 'spacing: 4px; padding: 5px;'
         });
 
+        let items = []; // Store items with their values for highlighting
+
+        function updateHighlight() {
+            // Highlight item matching current selectedTz
+            for (let itemData of items) {
+                if (itemData.value === selectedTz) {
+                    itemData.item.set_style('justify-content: flex-start; text-align: left; background-color: rgba(0, 100, 200, 0.3); border-radius: 5px; padding: 5px;');
+                } else {
+                    itemData.item.set_style('justify-content: flex-start; text-align: left;');
+                }
+            }
+        }
+
         for (let option of tzOptions) {
             let item = new St.Button({
                 label: option.label,
                 style: 'justify-content: flex-start; text-align: left;'
             });
+            
+            items.push({ item: item, value: option.value });
+            
             item.connect('clicked', () => {
                 selectedTz = option.value;
+                updateHighlight();
                 tzButton.set_label(tzLabel(selectedTz));
                 tzEntry.text = formatTz(selectedTz);
-                tzList.visible = false;
             });
             tzListBox.add_child(item);
         }
+
+        // Highlight the current selection on dialog open
+        updateHighlight();
 
         let tzList = new St.ScrollView({
             style: 'background: rgba(255,255,255,0.95); border: 1px solid rgba(0,0,0,0.2); max-height: 180px; width: 340px; margin-left: 10px; margin-right: 10px;',
@@ -264,19 +294,14 @@ const HdateButton = new GObject.registerClass({
             y_expand: false
         });
         tzList.add_child(tzListBox);
-        tzList.visible = true;
-
-        tzButton.connect('clicked', () => {
-            // Dropdown is now always visible, no toggle needed
-        });
 
         dialog.add_child(tzButton);
         dialog.add_child(tzList);
 
-        // Button container
+        // Button container (centered)
         let buttonBox = new St.BoxLayout({
             vertical: false,
-            style: 'spacing: 10px; margin: 10px;'
+            style: 'spacing: 10px; margin: 10px; justify-content: center;'
         });
 
         let okButton = new St.Button({
@@ -294,21 +319,23 @@ const HdateButton = new GObject.registerClass({
         dialog.add_child(buttonBox);
 
         // Create modal
-        let actor = new Clutter.Actor();
         let background = new St.Widget({
-            reactive: true,
-            x_expand: true,
-            y_expand: true,
-            style: 'background-color: rgba(0, 0, 0, 0.7);'
+            reactive: true
         });
+        
 
         let dialogContainer = new St.BoxLayout({
             vertical: true,
             reactive: true,
-            style: 'background-color: #f0f0f0; border-radius: 10px; padding: 20px; width: 360px; margin-top: 50px;'
+            style: 'background-color: #f0f0f0; border-radius: 10px; padding: 20px; width: 360px;'
         });
-        dialogContainer.set_x_align(Clutter.ActorAlign.CENTER);
-        dialogContainer.set_y_align(Clutter.ActorAlign.START);
+        
+        // Center horizontally and position near top
+        let monitor = Main.layoutManager.primaryMonitor;
+        dialogContainer.set_position(
+            Math.floor((monitor.width - 360) / 2), // Center horizontally
+            35 // Small offset from top
+        );
         dialogContainer.add_child(dialog);
 
         background.add_child(dialogContainer);
@@ -326,6 +353,7 @@ const HdateButton = new GObject.registerClass({
                 saveSettings(this.settings);
 
                 this._applySettings();
+                this._refresh_button_menu(); // Force menu refresh with new location
 
                 Main.uiGroup.remove_child(background);
                 background.destroy();

--- a/extension.js
+++ b/extension.js
@@ -10,10 +10,61 @@ import * as Config from  'resource:///org/gnome/shell/misc/config.js';
 import Clutter from 'gi://Clutter';
 import GObject from 'gi://GObject';
 import GLib from 'gi://GLib';
+import Gio from 'gi://Gio';
 
 import LibHDateGLib from 'gi://LibHdateGlib';
 
 let _hdateButton = null;
+
+// Settings management
+const SETTINGS_DIR = GLib.get_user_config_dir() + '/gnome-shell/extensions/hdate@hatul.info';
+const SETTINGS_FILE = SETTINGS_DIR + '/settings.json';
+
+function ensureSettingsDir() {
+    let dir = Gio.File.new_for_path(SETTINGS_DIR);
+    if (!dir.query_exists(null)) {
+        try {
+            dir.make_directory_with_parents(null);
+        } catch (e) {
+            logError(e);
+        }
+    }
+}
+
+function loadSettings() {
+    ensureSettingsDir();
+    let file = Gio.File.new_for_path(SETTINGS_FILE);
+
+    let defaults = { longitude: 34.77, latitude: 32.07, tz: 2 };
+
+    if (!file.query_exists(null)) {
+        return defaults;
+    }
+
+    try {
+        let [success, contents] = file.load_contents(null);
+        if (success) {
+            let data = JSON.parse(contents);
+            return Object.assign({}, defaults, data);
+        }
+    } catch (e) {
+        logError(e);
+    }
+
+    return defaults;
+}
+
+function saveSettings(settings) {
+    ensureSettingsDir();
+    let file = Gio.File.new_for_path(SETTINGS_FILE);
+    
+    try {
+        let data = JSON.stringify(settings);
+        file.replace_contents(data, null, false, Gio.FileCreateFlags.NONE, null);
+    } catch (e) {
+        logError(e);
+    }
+}
 
 const HdateButton = new GObject.registerClass({
     GTypeName: 'HdateButton'
@@ -27,13 +78,15 @@ const HdateButton = new GObject.registerClass({
         this.buttonText = new St.Label({y_expand: true, y_align: Clutter.ActorAlign.CENTER});
         this.add_child(this.buttonText);
         
+        // load settings
+        let settings = loadSettings();
+        this.settings = settings;
+        
         // init the hebrew date object
         this.h = LibHDateGLib.Hdate.new();
-        this.h.set_longitude(34.77);
-        this.h.set_latitude(32.07);
-        this.h.set_tz(2);
         this.h.set_dst(0);
         this.jd = 0;
+        this._applySettings();
 
         // force long format hebrew output
         this.h.set_use_hebrew(true);
@@ -47,6 +100,8 @@ const HdateButton = new GObject.registerClass({
         this._first_stars = null;
         this._three_stars = null;
         this._portion = null;
+        this._location = null;
+        this._settings_button = null;
         
         // check label and menu evry 60 secs
         this._refresh_rate = 60;
@@ -56,6 +111,16 @@ const HdateButton = new GObject.registerClass({
         this._refresh();
     }
     
+    _applySettings() {
+        // Ensure the internal libhdate object uses the configured location/timezone
+        this.h.set_longitude(this.settings.longitude);
+        this.h.set_latitude(this.settings.latitude);
+        this.h.set_tz(this.settings.tz);
+
+        this._refresh_button_menu(); // Force menu refresh with new location
+        this._refresh();
+    }
+
     _refresh_button_label() {
         // create the hebrew date label. we can use the standart this.h.to_string()
         // function or create the string.
@@ -79,6 +144,203 @@ const HdateButton = new GObject.registerClass({
         this.buttonText.set_text(label_string);
     }
     
+    _openSettingsDialog() {
+        let dialog = new St.BoxLayout({
+            vertical: true,
+            style_class: 'hddate-settings-dialog'
+        });
+        
+        let titleLabel = new St.Label({
+            text: _('Edit Location Settings'),
+            style_class: 'hddate-settings-title'
+        });
+        dialog.add_child(titleLabel);
+
+        // Longitude input
+        let longtitudeBox = new St.BoxLayout({
+            vertical: false,
+            style: 'spacing: 10px; margin: 10px;'
+        });
+        let lonLabel = new St.Label({ text: _('Longitude:') });
+        let lonInput = new St.Entry({
+            text: this.settings.longitude.toString(),
+            style: 'width: 150px;'
+        });
+        longtitudeBox.add_child(lonLabel);
+        longtitudeBox.add_child(lonInput);
+        dialog.add_child(longtitudeBox);
+
+        // Latitude input
+        let latitudeBox = new St.BoxLayout({
+            vertical: false,
+            style: 'spacing: 10px; margin: 10px;'
+        });
+        let latLabel = new St.Label({ text: _('Latitude:') });
+        let latInput = new St.Entry({
+            text: this.settings.latitude.toString(),
+            style: 'width: 150px;'
+        });
+        latitudeBox.add_child(latLabel);
+        latitudeBox.add_child(latInput);
+        dialog.add_child(latitudeBox);
+
+        // Time zone entry (free-form)
+        function formatTz(val) {
+            let sign = val >= 0 ? '+' : '';
+            return `UTC${sign}${val}`;
+        }
+
+        function parseTz(text) {
+            if (!text) return NaN;
+            let cleaned = text.toUpperCase().trim();
+            if (cleaned.startsWith('UTC'))
+                cleaned = cleaned.slice(3).trim();
+            // allow values like +2, -4, 2, 0
+            let num = parseFloat(cleaned);
+            return isNaN(num) ? NaN : num;
+        }
+
+        let tzEntry = new St.Entry({
+            text: formatTz(this.settings.tz),
+            style: 'width: 320px; margin: 10px;'
+        });
+        let tzEntryLabel = new St.Label({ text: _('Timezone (UTC offset):') });
+        let tzEntryBox = new St.BoxLayout({
+            vertical: false,
+            style: 'spacing: 10px; margin: 10px;'
+        });
+        tzEntryBox.add_child(tzEntryLabel);
+        tzEntryBox.add_child(tzEntry);
+        dialog.add_child(tzEntryBox);
+
+        // Time zone dropdown (common locations)
+        let tzOptions = [
+            { label: _('Jerusalem (UTC+2)'), value: 2 },
+            { label: _('New York (UTC-4)'), value: -4 },
+            { label: _('London (UTC+0)'), value: 0 },
+            { label: _('Paris (UTC+1)'), value: 1 },
+            { label: _('Moscow (UTC+3)'), value: 3 },
+            { label: _('Johannesburg (UTC+2)'), value: 2 },
+            { label: _('Buenos Aires (UTC-3)'), value: -3 },
+            { label: _('Los Angeles (UTC-7)'), value: -7 },
+            { label: _('Toronto (UTC-4)'), value: -4 },
+            { label: _('Melbourne (UTC+11)'), value: 11 }
+        ];
+
+        let selectedTz = this.settings.tz;
+
+        function tzLabel(val) {
+            let sign = val >= 0 ? '+' : '';
+            return _('Time zone:') + ` UTC${sign}${val}`;
+        }
+
+        let tzButton = new St.Button({
+            label: tzLabel(selectedTz),
+            style: 'width: 320px; margin: 10px; text-align: left;'
+        });
+
+        let tzListBox = new St.BoxLayout({
+            vertical: true,
+            style: 'spacing: 4px; padding: 5px;'
+        });
+
+        for (let option of tzOptions) {
+            let item = new St.Button({
+                label: option.label,
+                style: 'justify-content: flex-start; text-align: left;'
+            });
+            item.connect('clicked', () => {
+                selectedTz = option.value;
+                tzButton.set_label(tzLabel(selectedTz));
+                tzEntry.text = formatTz(selectedTz);
+                tzList.visible = false;
+            });
+            tzListBox.add_child(item);
+        }
+
+        let tzList = new St.ScrollView({
+            style: 'background: rgba(255,255,255,0.95); border: 1px solid rgba(0,0,0,0.2); max-height: 180px; width: 340px; margin-left: 10px; margin-right: 10px;',
+            x_expand: true,
+            y_expand: false
+        });
+        tzList.add_child(tzListBox);
+        tzList.visible = true;
+
+        tzButton.connect('clicked', () => {
+            // Dropdown is now always visible, no toggle needed
+        });
+
+        dialog.add_child(tzButton);
+        dialog.add_child(tzList);
+
+        // Button container
+        let buttonBox = new St.BoxLayout({
+            vertical: false,
+            style: 'spacing: 10px; margin: 10px;'
+        });
+
+        let okButton = new St.Button({
+            label: _('OK'),
+            style_class: 'button'
+        });
+
+        let cancelButton = new St.Button({
+            label: _('Cancel'),
+            style_class: 'button'
+        });
+
+        buttonBox.add_child(okButton);
+        buttonBox.add_child(cancelButton);
+        dialog.add_child(buttonBox);
+
+        // Create modal
+        let actor = new Clutter.Actor();
+        let background = new St.Widget({
+            reactive: true,
+            x_expand: true,
+            y_expand: true,
+            style: 'background-color: rgba(0, 0, 0, 0.7);'
+        });
+
+        let dialogContainer = new St.BoxLayout({
+            vertical: true,
+            reactive: true,
+            style: 'background-color: #f0f0f0; border-radius: 10px; padding: 20px; width: 360px; margin-top: 50px;'
+        });
+        dialogContainer.set_x_align(Clutter.ActorAlign.CENTER);
+        dialogContainer.set_y_align(Clutter.ActorAlign.START);
+        dialogContainer.add_child(dialog);
+
+        background.add_child(dialogContainer);
+
+        okButton.connect('clicked', () => {
+            let lon = parseFloat(lonInput.text);
+            let lat = parseFloat(latInput.text);
+            let tzFromEntry = parseTz(tzEntry.text);
+            let tz = !isNaN(tzFromEntry) ? tzFromEntry : selectedTz;
+
+            if (!isNaN(lon) && !isNaN(lat)) {
+                this.settings.longitude = lon;
+                this.settings.latitude = lat;
+                this.settings.tz = tz;
+                saveSettings(this.settings);
+
+                this._applySettings();
+
+                Main.uiGroup.remove_child(background);
+                background.destroy();
+            }
+        });
+
+        cancelButton.connect('clicked', () => {
+            Main.uiGroup.remove_child(background);
+            background.destroy();
+        });
+
+        Main.uiGroup.add_child(background);
+    }
+    
+    
     _refresh_button_menu() {
         // remove the old menu items
         if (this._sunrise)
@@ -95,6 +357,10 @@ const HdateButton = new GObject.registerClass({
             this._three_stars.destroy();
         if (this._portion)
             this._portion.destroy();
+        if (this._location)
+            this._location.destroy();
+        if (this._settings_button)
+            this._settings_button.destroy();
 
         // get the time-of-day times
         var sunrise = this.h.get_sunrise()
@@ -170,6 +436,23 @@ const HdateButton = new GObject.registerClass({
         this.menu.addMenuItem(this._three_stars);
         this.menu.addMenuItem(this._sep2);
         this.menu.addMenuItem(this._portion);
+
+        // Current location info
+        this._location = new PopupMenu.PopupMenuItem(
+            _('Location: ') + `${this.settings.longitude.toFixed(2)}, ${this.settings.latitude.toFixed(2)} (UTC${this.settings.tz >= 0 ? '+' : ''}${this.settings.tz})`);
+        this._location.setSensitive(false);
+        this.menu.addMenuItem(this._location);
+
+        // Add settings separator and button
+        let sep3 = new PopupMenu.PopupSeparatorMenuItem();
+        this.menu.addMenuItem(sep3);
+
+        this._settings_button = new PopupMenu.PopupMenuItem(
+            _('Location Settings ⚙'));
+        this._settings_button.connect('activate', () => {
+            this._openSettingsDialog();
+        });
+        this.menu.addMenuItem(this._settings_button);
     }
     
     _refresh() {

--- a/extension.js
+++ b/extension.js
@@ -155,7 +155,6 @@ const HdateButton = new GObject.registerClass({
         let titleLabel = new St.Label({
             text: _('Edit Location Settings'),
             style_class: 'hddate-settings-title',
-            style: 'font-size: 16px; font-weight: bold;',
             x_align: Clutter.ActorAlign.CENTER,
             x_expand: true
         });
@@ -164,22 +163,22 @@ const HdateButton = new GObject.registerClass({
         // Create table-like layout for coordinates using BoxLayout
         let coordContainer = new St.BoxLayout({
             vertical: true,
-            style: 'spacing: 10px; margin: 10px;'
+            style_class: 'hddate-coord-container'
         });
 
         // Latitude row
         let latBox = new St.BoxLayout({
             vertical: false,
-            style: 'spacing: 10px;'
+            style_class: 'hddate-coord-row'
         });
-        let latLabel = new St.Label({ 
-            text: _('Latitude (°N):'), 
-            style: 'width: 120px;',
+        let latLabel = new St.Label({
+            text: _('Latitude (°N):'),
+            style_class: 'hddate-coord-label',
             y_align: Clutter.ActorAlign.CENTER
         });
         let latInput = new St.Entry({
             text: this.settings.latitude.toString(),
-            style: 'width: 150px;',
+            style_class: 'hddate-coord-input',
             y_align: Clutter.ActorAlign.CENTER
         });
         latBox.add_child(latLabel);
@@ -189,16 +188,16 @@ const HdateButton = new GObject.registerClass({
         // Longitude row
         let lonBox = new St.BoxLayout({
             vertical: false,
-            style: 'spacing: 10px;'
+            style_class: 'hddate-coord-row'
         });
-        let lonLabel = new St.Label({ 
-            text: _('Longitude (°E):'), 
-            style: 'width: 120px;',
+        let lonLabel = new St.Label({
+            text: _('Longitude (°E):'),
+            style_class: 'hddate-coord-label',
             y_align: Clutter.ActorAlign.CENTER
         });
         let lonInput = new St.Entry({
             text: this.settings.longitude.toString(),
-            style: 'width: 150px;',
+            style_class: 'hddate-coord-input',
             y_align: Clutter.ActorAlign.CENTER
         });
         lonBox.add_child(lonLabel);
@@ -226,16 +225,16 @@ const HdateButton = new GObject.registerClass({
 
         let tzEntry = new St.Entry({
             text: formatTz(this.settings.tz),
-            style: 'width: 70px; margin: 10px;',
+            style_class: 'hddate-tz-entry',
             y_align: Clutter.ActorAlign.CENTER
         });
-        let tzEntryLabel = new St.Label({ 
+        let tzEntryLabel = new St.Label({
             text: _('Timezone (UTC offset):'),
             y_align: Clutter.ActorAlign.CENTER
         });
         let tzEntryBox = new St.BoxLayout({
             vertical: false,
-            style: 'spacing: 10px; margin: 10px;'
+            style_class: 'hddate-tz-entry-box'
         });
         tzEntryBox.add_child(tzEntryLabel);
         tzEntryBox.add_child(tzEntry);
@@ -260,7 +259,7 @@ const HdateButton = new GObject.registerClass({
 
         let tzListBox = new St.BoxLayout({
             vertical: true,
-            style: 'spacing: 4px; padding: 5px;'
+            style_class: 'hddate-tz-list-box'
         });
 
         let items = []; // Store items with their values for highlighting
@@ -269,9 +268,9 @@ const HdateButton = new GObject.registerClass({
             // Highlight item matching current selectedTz
             for (let itemData of items) {
                 if (itemData.value === selectedTz) {
-                    itemData.item.set_style('justify-content: flex-start; text-align: left; background-color: rgba(0, 100, 200, 0.3); border-radius: 5px; padding: 5px;');
+                    itemData.item.add_style_class_name('hddate-tz-item-selected');
                 } else {
-                    itemData.item.set_style('justify-content: flex-start; text-align: left;');
+                    itemData.item.remove_style_class_name('hddate-tz-item-selected');
                 }
             }
         }
@@ -279,7 +278,7 @@ const HdateButton = new GObject.registerClass({
         for (let option of tzOptions) {
             let item = new St.Button({
                 label: option.label,
-                style: 'justify-content: flex-start; text-align: left;'
+                style_class: 'hddate-tz-item'
             });
             
             items.push({ item: item, value: option.value });
@@ -296,8 +295,7 @@ const HdateButton = new GObject.registerClass({
         updateHighlight();
 
         let tzList = new St.ScrollView({
-            style_class: 'popup-menu-content',
-            style: 'background-color: rgba(0,0,0,0.05); max-height: 180px; width: 340px; margin-left: 10px; margin-right: 10px; border: 1px solid rgba(0,0,0,0.15);',
+            style_class: 'popup-menu-content hddate-tz-list',
             x_expand: true,
             y_expand: false
         });
@@ -309,22 +307,20 @@ const HdateButton = new GObject.registerClass({
         // Button container
         let buttonBox = new St.BoxLayout({
             vertical: false,
-            style: 'margin-left: 10px; margin-right: 10px; margin-top: 10px; margin-bottom: 10px;',
+            style_class: 'hddate-button-box',
             x_expand: true
         });
 
         let okButton = new St.Button({
             label: _('OK'),
-            style_class: 'button',
-            x_expand: false,
-            style: 'margin-left: 10px;'
+            style_class: 'button hddate-ok-button',
+            x_expand: false
         });
 
         let cancelButton = new St.Button({
             label: _('Cancel'),
-            style_class: 'button',
-            x_expand: false,
-            style: 'margin-right: 10px;'
+            style_class: 'button hddate-cancel-button',
+            x_expand: false
         });
 
         buttonBox.add_child(okButton);
@@ -347,8 +343,7 @@ const HdateButton = new GObject.registerClass({
         let dialogContainer = new St.BoxLayout({
             vertical: true,
             reactive: true,
-            style_class: 'popup-menu-content',
-            style: 'border-radius: 10px; padding: 20px; width: 360px;'
+            style_class: 'popup-menu-content hddate-dialog-container'
         });
         
         // Center horizontally and position near top

--- a/extension.js
+++ b/extension.js
@@ -117,7 +117,7 @@ const HdateButton = new GObject.registerClass({
         this.h.set_latitude(this.settings.latitude);
         this.h.set_tz(this.settings.tz);
 
-        this.h.set_use_hebrew(true);
+        this.h.set_use_hebrew(true); // I don't know why I need to reset this, but otherwise it appears as English
         this.h.set_use_short_format(false);
 
         // Don't call _refresh_button_menu() here - _refresh() will handle it
@@ -154,7 +154,10 @@ const HdateButton = new GObject.registerClass({
         
         let titleLabel = new St.Label({
             text: _('Edit Location Settings'),
-            style_class: 'hddate-settings-title'
+            style_class: 'hddate-settings-title',
+            style: 'font-size: 16px; font-weight: bold;',
+            x_align: Clutter.ActorAlign.CENTER,
+            x_expand: true
         });
         dialog.add_child(titleLabel);
 
@@ -169,10 +172,15 @@ const HdateButton = new GObject.registerClass({
             vertical: false,
             style: 'spacing: 10px;'
         });
-        let latLabel = new St.Label({ text: _('Latitude (°N):'), style: 'width: 120px;' });
+        let latLabel = new St.Label({ 
+            text: _('Latitude (°N):'), 
+            style: 'width: 120px;',
+            y_align: Clutter.ActorAlign.CENTER
+        });
         let latInput = new St.Entry({
             text: this.settings.latitude.toString(),
-            style: 'width: 150px;'
+            style: 'width: 150px;',
+            y_align: Clutter.ActorAlign.CENTER
         });
         latBox.add_child(latLabel);
         latBox.add_child(latInput);
@@ -183,10 +191,15 @@ const HdateButton = new GObject.registerClass({
             vertical: false,
             style: 'spacing: 10px;'
         });
-        let lonLabel = new St.Label({ text: _('Longitude (°E):'), style: 'width: 120px;' });
+        let lonLabel = new St.Label({ 
+            text: _('Longitude (°E):'), 
+            style: 'width: 120px;',
+            y_align: Clutter.ActorAlign.CENTER
+        });
         let lonInput = new St.Entry({
             text: this.settings.longitude.toString(),
-            style: 'width: 150px;'
+            style: 'width: 150px;',
+            y_align: Clutter.ActorAlign.CENTER
         });
         lonBox.add_child(lonLabel);
         lonBox.add_child(lonInput);
@@ -195,7 +208,7 @@ const HdateButton = new GObject.registerClass({
         dialog.add_child(coordContainer);
 
 
-        // Time zone entry (free-form)
+        // Time zone entry (text input with dropdown options below)
         function formatTz(val) {
             let sign = val >= 0 ? '+' : '';
             return `UTC${sign}${val}`;
@@ -292,37 +305,42 @@ const HdateButton = new GObject.registerClass({
         dialog.add_child(tzEntryBox);
         dialog.add_child(tzList);
 
-        // Button container (centered)
+        // Button container
         let buttonBox = new St.BoxLayout({
             vertical: false,
-            style: 'spacing: 10px; margin: 10px; justify-content: center;'
+            style: 'margin-left: 10px; margin-right: 10px; margin-top: 10px; margin-bottom: 10px;',
+            x_expand: true
         });
 
         let okButton = new St.Button({
             label: _('OK'),
-            style_class: 'button'
+            style_class: 'button',
+            x_expand: false,
+            style: 'margin-left: 10px;'
         });
 
         let cancelButton = new St.Button({
             label: _('Cancel'),
-            style_class: 'button'
+            style_class: 'button',
+            x_expand: false,
+            style: 'margin-right: 10px;'
         });
 
         buttonBox.add_child(okButton);
+        
+        // Add spacer between buttons
+        let spacer = new St.Widget({
+            x_expand: true
+        });
+        buttonBox.add_child(spacer);
+        
         buttonBox.add_child(cancelButton);
         dialog.add_child(buttonBox);
 
-        // Create modal
+        // Create modal background
         let background = new St.Widget({
             reactive: true
         });
-        
-        // Push modal to capture input
-        let modalParams = {
-            actionMode: Shell.ActionMode.ALL,
-            shouldTakeFocus: true
-        };
-        Main.pushModal(background, modalParams);
         
 
         let dialogContainer = new St.BoxLayout({
@@ -335,14 +353,13 @@ const HdateButton = new GObject.registerClass({
         let monitor = Main.layoutManager.primaryMonitor;
         dialogContainer.set_position(
             Math.floor((monitor.width - 360) / 2), // Center horizontally
-            35 // Small offset from top
+            40 // Small offset from top
         );
         dialogContainer.add_child(dialog);
 
         background.add_child(dialogContainer);
 
         let closeDialog = () => {
-            Main.popModal(background);
             Main.uiGroup.remove_child(background);
             background.destroy();
         };

--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,10 @@
   "name": "Gnome HDate",
   "shell-version": [
     "45",
-    "46"
+    "46",
+    "47",
+    "48",
+    "49"
   ],
   "url": "https://github.com/amiad/gnome-hdate",
   "uuid": "hdate@hatul.info",

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,0 +1,88 @@
+/* Settings dialog title */
+.hddate-settings-title {
+    font-size: 16px;
+    font-weight: bold;
+}
+
+/* Coordinate input container */
+.hddate-coord-container {
+    spacing: 10px;
+    margin: 10px;
+}
+
+/* Coordinate row (label + input side by side) */
+.hddate-coord-row {
+    spacing: 10px;
+}
+
+/* Coordinate labels */
+.hddate-coord-label {
+    width: 120px;
+}
+
+/* Coordinate text inputs */
+.hddate-coord-input {
+    width: 150px;
+}
+
+/* Timezone entry field */
+.hddate-tz-entry {
+    width: 70px;
+    margin: 10px;
+}
+
+/* Timezone entry row */
+.hddate-tz-entry-box {
+    spacing: 10px;
+    margin: 10px;
+}
+
+/* Inner timezone list box */
+.hddate-tz-list-box {
+    spacing: 4px;
+    padding: 5px;
+}
+
+/* Timezone scroll view */
+.hddate-tz-list {
+    background-color: rgba(0, 0, 0, 0.05);
+    max-height: 180px;
+    width: 340px;
+    margin-inline-start: 10px;
+    margin-inline-end: 10px;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+}
+
+/* Individual timezone button — use logical alignment for RTL support */
+.hddate-tz-item {
+    text-align: start;
+}
+
+/* Selected timezone button */
+.hddate-tz-item-selected {
+    background-color: rgba(0, 100, 200, 0.3);
+    border-radius: 5px;
+    padding: 5px;
+}
+
+/* OK / Cancel button row */
+.hddate-button-box {
+    margin: 10px;
+}
+
+/* Extra start-side margin on OK button */
+.hddate-ok-button {
+    margin-inline-start: 10px;
+}
+
+/* Extra end-side margin on Cancel button */
+.hddate-cancel-button {
+    margin-inline-end: 10px;
+}
+
+/* Outer dialog container */
+.hddate-dialog-container {
+    border-radius: 10px;
+    padding: 20px;
+    width: 360px;
+}


### PR DESCRIPTION
The current module had the location (which is needed for core zmanim functionality) hard coded into the JavaScript. This was unintuitive for me and makes it hard for the average user (not that they exist lol) to change it to the appropriate time zone and location. I added a settings menu to edit the time zone and coordinates which is opened directly from the zmanim drop down. The settings are saved locally to persist across resets. 

<img width="784" height="793" alt="image" src="https://github.com/user-attachments/assets/01aed7e5-ccf3-47d7-b266-b0944a149cff" />

<img width="784" height="793" alt="image" src="https://github.com/user-attachments/assets/a83649cb-d8fa-40c2-95a9-5cb0d6d891c1" />
